### PR TITLE
Fix .yt replying to links with links

### DIFF
--- a/dist/plugins/Youtube.plugin.js
+++ b/dist/plugins/Youtube.plugin.js
@@ -27,7 +27,9 @@ class Youtube {
                 const query = text.replace(/\.yt |www\./g, '');
                 this.search(query, options, (err, results) => {
                     const destination = channel === this.client.nick ? from : channel;
-                    const searchIsUrl = -1 < youtubeUrls.findIndex((url) => url === query.split('/')[2]);
+                    const searchIsUrl = -1 < youtubeUrls.findIndex((url) => {
+                        return url === query.toLowerCase().split('/')[2];
+                    });
                     let msg;
                     if (err || results.length === 0) {
                         msg = 'No results found.';

--- a/dist/plugins/Youtube.plugin.js
+++ b/dist/plugins/Youtube.plugin.js
@@ -22,46 +22,24 @@ class Youtube {
             if (configService.ignoringUser(message)) {
                 return;
             }
-            let usingDotYT = false;
             if (text.startsWith('.yt ') && text.length > 4) {
-                usingDotYT = true;
-                const query = text.replace('.yt ', '');
+                const youtubeUrls = ['youtube.com', 'youtu.be'];
+                const query = text.replace(/\.yt |www\./g, '');
                 this.search(query, options, (err, results) => {
                     const destination = channel === this.client.nick ? from : channel;
+                    const searchIsUrl = -1 < youtubeUrls.findIndex((url) => url === query.split('/')[2]);
+                    let msg;
                     if (err || results.length === 0) {
-                        client.say(destination, 'No results found.');
-                        return;
+                        msg = 'No results found.';
                     }
-                    client.say(destination, `${results[0].link} - ${results[0].title}`);
+                    else if (searchIsUrl) {
+                        msg = `Title: ${results[0].title}`;
+                    }
+                    else {
+                        msg = `${results[0].link} - ${results[0].title}`;
+                    }
+                    client.say(destination, msg);
                 });
-            }
-            if (usingDotYT) {
-                return;
-            }
-            const youtubeUrls = [
-                'https://www.youtube.com/',
-                'http://www.youtube.com/',
-                'https://youtube.com/',
-                'https://youtube.com/',
-                'http://youtu.be/',
-                'https://youtu.be/',
-            ];
-            const urlMatches = text.match(/\bhttps?:\/\/\S+/gi);
-            if (urlMatches && urlMatches.length > 0) {
-                const firstUrl = urlMatches.find((url) => {
-                    return youtubeUrls.find(ytUrl => url.toLowerCase().startsWith(ytUrl));
-                });
-                // console.log({ firstUrl });
-                if (firstUrl) {
-                    this.search(firstUrl, options, (err, results) => {
-                        const destination = channel === this.client.nick ? from : channel;
-                        if (err || results.length === 0) {
-                            // client.say(destination, 'No results found.');
-                            return;
-                        }
-                        client.say(destination, `${from}: ${results[0].title}`);
-                    });
-                }
             }
         });
         return true;

--- a/src/plugins/Youtube.plugin.ts
+++ b/src/plugins/Youtube.plugin.ts
@@ -31,7 +31,9 @@ class Youtube {
 
                 this.search(query, options, (err: Error, results: YouTubeSearchResults[]) => {
                     const destination = channel === this.client.nick ? from : channel;
-                    const searchIsUrl = -1 < youtubeUrls.findIndex((url: string) => url === query.split('/')[2]);
+                    const searchIsUrl = -1 < youtubeUrls.findIndex((url: string) => {
+                        return url === query.toLowerCase().split('/')[2];
+                    });
                     let msg;
 
                     if (err || results.length === 0) {

--- a/src/plugins/Youtube.plugin.ts
+++ b/src/plugins/Youtube.plugin.ts
@@ -25,58 +25,25 @@ class Youtube {
                 return;
             }
 
-            let usingDotYT = false;
-
             if (text.startsWith('.yt ') && text.length > 4) {
-                usingDotYT = true;
-                const query = text.replace('.yt ', '');
+                const youtubeUrls = [ 'youtube.com', 'youtu.be' ];
+                const query = text.replace(/\.yt |www\./g, '');
 
                 this.search(query, options, (err: Error, results: YouTubeSearchResults[]) => {
                     const destination = channel === this.client.nick ? from : channel;
+                    const searchIsUrl = -1 < youtubeUrls.findIndex((url: string) => url === query.split('/')[2]);
+                    let msg;
 
                     if (err || results.length === 0) {
-                        client.say(destination, 'No results found.');
-                        return;
+                        msg = 'No results found.';
+                    } else if (searchIsUrl) {
+                        msg = `Title: ${results[0].title}`;
+                    } else {
+                        msg = `${results[0].link} - ${results[0].title}`;
                     }
 
-                    client.say(destination, `${results[0].link} - ${results[0].title}`);
+                    client.say(destination, msg);
                 });
-            }
-
-            if (usingDotYT) {
-                return;
-            }
-
-            const youtubeUrls = [
-                'https://www.youtube.com/', //
-                'http://www.youtube.com/',
-                'https://youtube.com/',
-                'https://youtube.com/',
-                'http://youtu.be/',
-                'https://youtu.be/',
-            ];
-
-            const urlMatches = text.match(/\bhttps?:\/\/\S+/gi);
-
-            if (urlMatches && urlMatches.length > 0) {
-                const firstUrl = urlMatches.find((url: string) => {
-                    return youtubeUrls.find(ytUrl => url.toLowerCase().startsWith(ytUrl));
-                });
-
-                // console.log({ firstUrl });
-
-                if (firstUrl) {
-                    this.search(firstUrl, options, (err: Error, results: YouTubeSearchResults[]) => {
-                        const destination = channel === this.client.nick ? from : channel;
-
-                        if (err || results.length === 0) {
-                            // client.say(destination, 'No results found.');
-                            return;
-                        }
-
-                        client.say(destination, `${from}: ${results[0].title}`);
-                    });
-                }
             }
         });
 

--- a/tests/plugins/Youtube.test.js
+++ b/tests/plugins/Youtube.test.js
@@ -110,7 +110,7 @@ it('does not respond to ignored user', done => {
     done();
 });
 
-it('sees youtube link and says title', done => {
+it('only includes title if search is a youtube link', done => {
     // ARRANGE
     const pluginInstance = require('../../dist/plugins/Youtube.plugin.js');
 
@@ -131,13 +131,13 @@ it('sees youtube link and says title', done => {
 
     // ACT
     const pluginLoaded = pluginInstance.load(client, configService, env);
-    client.emit('message', 'otherperson', '#some-channel', 'https://www.youtube.com/watch?v=6Mf2ylffKws check this out');
+    client.emit('message', 'otherperson', '#some-channel', '.yt https://www.youtube.com/watch?v=6Mf2ylffKws');
 
     // ASSERT
     expect(pluginLoaded).toBe(true);
     expect(client.say.mock.calls.length).toBe(1); // Bot should have responded.
     expect(client.say.mock.calls[0][0]).toBe('#some-channel');
-    expect(client.say.mock.calls[0][1]).toBe('otherperson: Ridiculous Actor Demands That Forced Movie Details To Change');
+    expect(client.say.mock.calls[0][1]).toBe('Title: Ridiculous Actor Demands That Forced Movie Details To Change');
 
     done();
 });


### PR DESCRIPTION
Rewrites the `.yt` command to enable differing responses based on the search text.

By stripping the `www.` and splitting on `/`, the `youtubeUrls` array can be significantly shorter - all we need to check is the domain and not `http` vs `https` or `www` vs plain-domain.

Since the search has already been done, all we care about is whether or not it matched so we can use `findIndex` too, instead of returning the matching part of the text which was previously giving some error about not being assignable to boolean.

![image](https://user-images.githubusercontent.com/1521802/54729613-7dcb1580-4b7c-11e9-8759-22017518b185.png)
